### PR TITLE
descramble_tcpdump_...AQ&AD updated so that they work with the latest…

### DIFF
--- a/calibration/conf/default.yaml
+++ b/calibration/conf/default.yaml
@@ -26,10 +26,15 @@ gather:
 
         output_prefix: "p2018.03.15crdAD_h10"
 
-        descramble_tcpdump_2018_03_15ad: &descramble_tcpdump_2018_03_15ad
+        # older Firmware, using (pack_number) to id a packet
+        descramble_tcpdump_2018_03_15ad: 
             save_file: True
             clean_memory: True
             verbose: True
+            multiple_save_files: True
+            # multiple_metadata_file: /home/prcvlusr/PercAuxiliaryTools/PercPython/data/testFramework/2018.05.25/try1/VRST=10k_AD_10frames_meta.dat
+            multiple_metadata_file: /home/prcvlusr/PercAuxiliaryTools/PercPython/data/testFramework/2018.05.25/try1/p2018.03.15crdAD_h20_meta.dat
+            multiple_imgperfile: 1
 
             n_adc: 7
             n_grp: 212
@@ -37,6 +42,7 @@ gather:
 
             n_col_in_blk: 32
 
+        # more up-to-date Firmware, using (datatype,subframe,pack) triplet to id a packet
         descramble_tcpdump_2018_04_13aq:
             save_file: True
             clean_memory: True

--- a/calibration/src/gather/descramble/methods/descramble_tcpdump_2018_04_13aq.py
+++ b/calibration/src/gather/descramble/methods/descramble_tcpdump_2018_04_13aq.py
@@ -266,8 +266,7 @@ class Descramble(DescrambleBase):
 
         for i, prefix in enumerate(fileprefix_list):
 
-            filepath = os.path.dirname(self._output_fname,
-                                       prefix + ".h5")
+            filepath = os.path.dirname(self._output_fname) + '/'+ prefix + ".h5"
 
             with h5py.File(filepath, "w", libver='latest') as my5hfile:
                 my5hfile.create_dataset('/data/', data=sample[i, :, :, :])


### PR DESCRIPTION
… yaml file format; also multiple file creation

1) some modification were necessary to descramble_tcpdump_2018_04_13aq.py to work properly with the latest yaml file format: they are included here

2) descramble_tcpdump_2018_03_23ad.py has been revised so that its outputs match the outputs of  descramble_tcpdump_2018_04_13aq.py (i.e. it can generates a single h5 file or multiple h5 files)

3) as a consequence of 2), descramble_tcpdump_2018_03_23ad.py  needs a few more input variables than it was written in the yaml file: the file calib/conf/default.yaml has been updated 